### PR TITLE
fix memory leak

### DIFF
--- a/include/efanna2e/index.h
+++ b/include/efanna2e/index.h
@@ -45,10 +45,10 @@ class Index {
   inline const float *GetDataset() const { return data_; }
  protected:
   const size_t dimension_;
-  const float *data_;
+  const float *data_ = nullptr;
   size_t nd_;
   bool has_built;
-  Distance* distance_;
+  Distance* distance_ = nullptr;
 };
 
 }

--- a/include/efanna2e/index_nsg.h
+++ b/include/efanna2e/index_nsg.h
@@ -47,7 +47,7 @@ class IndexNSG : public Index {
 
     CompactGraph final_graph_;
 
-    Index *initializer_;
+    Index *initializer_ = nullptr;
     void init_graph(const Parameters &parameters);
     void get_neighbors(
         const float *query,
@@ -74,7 +74,7 @@ class IndexNSG : public Index {
     unsigned width;
     unsigned ep_;
     std::vector<std::mutex> locks;
-    char* opt_graph_;
+    char* opt_graph_ = nullptr;
     size_t node_size;
     size_t data_len;
     size_t neighbor_len;

--- a/src/index_nsg.cpp
+++ b/src/index_nsg.cpp
@@ -15,7 +15,20 @@ IndexNSG::IndexNSG(const size_t dimension, const size_t n, Metric m,
                    Index *initializer)
     : Index(dimension, n, m), initializer_{initializer} {}
 
-IndexNSG::~IndexNSG() {}
+IndexNSG::~IndexNSG() {
+    if (distance_ != nullptr) {
+        delete distance_;
+        distance_ = nullptr;
+    }
+    if (initializer_ != nullptr) {
+        delete initializer_;
+        initializer_ = nullptr;
+    }
+    if (opt_graph_ != nullptr) {
+        delete opt_graph_;
+        opt_graph_ = nullptr;
+    }
+}
 
 void IndexNSG::Save(const char *filename) {
   std::ofstream out(filename, std::ios::binary | std::ios::out);
@@ -223,6 +236,7 @@ void IndexNSG::init_graph(const Parameters &parameters) {
   ep_ = rand() % nd_;  // random initialize navigating point
   get_neighbors(center, parameters, tmp, pool);
   ep_ = tmp[0].id;
+  delete center;
 }
 
 void IndexNSG::sync_prune(unsigned q, std::vector<Neighbor> &pool,
@@ -422,6 +436,7 @@ void IndexNSG::Build(size_t n, const float *data, const Parameters &parameters) 
   printf("Degree Statistics: Max = %d, Min = %d, Avg = %d\n", max, min, avg);
 
   has_built = true;
+  delete cut_graph_;
 }
 
 void IndexNSG::Search(const float *query, const float *x, size_t K,


### PR DESCRIPTION
only fix memory leak.

back ground:
when integrate nsg to our commercial products , we found that there are many memory leak every time we build or load nsg index files .