### PR TITLE
Distance Computation: Fix SSE instructions

### DIFF
--- a/include/efanna2e/distance.h
+++ b/include/efanna2e/distance.h
@@ -165,10 +165,10 @@ namespace efanna2e{
 #else
 #ifdef __SSE2__
       #define SSE_DOT(addr1, addr2, dest, tmp1, tmp2) \
-          tmp1 = _mm128_loadu_ps(addr1);\
-          tmp2 = _mm128_loadu_ps(addr2);\
-          tmp1 = _mm128_mul_ps(tmp1, tmp2); \
-          dest = _mm128_add_ps(dest, tmp1);
+          tmp1 = _mm_loadu_ps(addr1);\
+          tmp2 = _mm_loadu_ps(addr2);\
+          tmp1 = _mm_mul_ps(tmp1, tmp2); \
+          dest = _mm_add_ps(dest, tmp1);
       __m128 sum;
       __m128 l0, l1, l2, l3;
       __m128 r0, r1, r2, r3;
@@ -258,9 +258,9 @@ namespace efanna2e{
 #else
 #ifdef __SSE2__
 #define SSE_L2NORM(addr, dest, tmp) \
-    tmp = _mm128_loadu_ps(addr); \
-    tmp = _mm128_mul_ps(tmp, tmp); \
-    dest = _mm128_add_ps(dest, tmp);
+    tmp = _mm_loadu_ps(addr); \
+    tmp = _mm_mul_ps(tmp, tmp); \
+    dest = _mm_add_ps(dest, tmp);
 
     __m128 sum;
     __m128 l0, l1, l2, l3;

--- a/pynsg/README.md
+++ b/pynsg/README.md
@@ -18,7 +18,12 @@ This package provides Python bindings for the original NSG implementation:
 - **Original Authors**: Cong Fu, Chao Xiang, Changxu Wang, Deng Cai
 - **Python Bindings**: Created to enable easy integration with Python-based machine learning workflows (such as the ANN benchmarks)
 
-## Hardware Requirements
+## Requirements
+The CPP code requires g++, cmake, libboost-dev and libgoogle-perftools-dev, which can be installed via 
+```sudo apt-get install g++ cmake libboost-dev libgoogle-perftools-dev```.
+All Python dependencies will be installed automatically. 
+
+### Hardware
 
 The underlying CPP implementation of NSG requires both OpenMP and AVX2.
 
@@ -92,12 +97,6 @@ Available distance metrics:
 - `Metric.L2`: Standard L2 (Euclidean) distance
 > [!NOTE]
 > While cosine similarity is not directly exposed, it can be computed by first normalizing the vectors and then using L2.
-
-## Requirements
-
-- Python 3.6+
-- NumPy >= 1.16.0
-- A k-NN graph file (can be generated using tools like FAISS or other ANN libraries)
 
 ## Generating k-NN Graphs
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 from setuptools import Extension, setup, find_packages
 from setuptools.command.build_ext import build_ext
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 def has_flag(compiler, flagname):
     """Return a boolean indicating whether a flag name is supported on


### PR DESCRIPTION
The distance computations use SSE instructions that don't exist, making the compilation fail on machines that only support SSE [1]. Replace instructions like '_mm128_loadu_ps' with the correct '_mm_loadu_ps'.

This PR also slightly alters the Python bindings' documentation to mention the required libraries for compilation.

[1] https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html

 